### PR TITLE
Modify apt-get instructions slightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You need the Python `enum`, `scapy`, and `pycrypto` packages.
 
 On a Debian system:
 
-`sudo apt-get install python-enum scapy python-crypto`
+`sudo apt-get install python-enum python-pyasn1 scapy python-crypto`
 
 and also run
 


### PR DESCRIPTION
python-pyasn1 is needed when using apt-get also.
