### PR TITLE
[sheran] Added check to import pycrypto if installed in lowercase dir

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -5,7 +5,12 @@ from enum import Enum
 import time
 import datetime
 import socket
-import Crypto.Cipher
+# In case your pip install pycrypto has placed the module in lowercase directories
+try:
+    import Crypto.Cipher
+except ImportError:
+    import crypto
+    sys.modules['Crypto'] = crypto
 import signal
 from binascii import hexlify
 import base64


### PR DESCRIPTION
I had difficulty using scanner.py on OS X Yosemite because the `pip install pycrypto` placed the module in a lowercase directory. Thus the `import Crypto.Cipher` did not work. This PR hopefully addresses the problem. Tested and works on my OS X 10.10.5, Python 2.7.10.
