### PR TITLE
Adding python-pip to Debian Prereqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Pull requests clarifying the dependency list (and also general PRs) are welcome.
 
 ### On a Debian system:
 
-`sudo apt-get install tcpdump python-enum python-pyasn1 scapy python-crypto`
+`sudo apt-get install tcpdump python-enum python-pyasn1 scapy python-crypto python-pip`
 
 and also run
 


### PR DESCRIPTION
Adding the Debian package python-pip to the pre-reqs list, since pip is referenced in the very next step and may not automatically be installed otherwise.
